### PR TITLE
exclude SeaQL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,8 @@ users:
   - name: loljoshie
   - name: project-codex
   - name: 5m1Ly
+    excludeRepos:
+      - SeaQL
   - name: RodericAguilar
   - name: hoangducdt
   - name: vCodeScripts


### PR DESCRIPTION
I added an exclude rule for the SeaQL repo i created, because the code needs to be reworked or i'll maintainment entirely because a lot of people miss understood the purpose of the resource.